### PR TITLE
Fix relative path resolution for TLS certificate and key by using the config folder as the base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ The server:
 Server configuration is managed via `config/config.json`, which defines:
 
 - **`SERVER_PORT`** — the port on which the MCP server listens for client connections (required only for the remote server)
-- **`TLS_CERT_PATH`** — path to the file containing the certificate for TLS
-- **`TLS_KEY_PATH`** — path to the file containing the private key for TLS
+- **`TLS_CERT_PATH`** — path to the file containing the certificate for TLS, either absolute or relative to the configuration folder
+- **`TLS_KEY_PATH`** — path to the file containing the private key for TLS, either absolute or relative to the configuration folder
 - **`TLS_KEY_PASSPHRASE`** — (optional) passphrase for the **`TLS_KEY_PATH`** file
 - **`MCP_SERVER_CORS_ORIGINS`** — CORS origin allowed
 - **`MCP_SERVER_DNS_REBINDING_PROTECTION_ALLOWED_HOSTS`** - list of allowed values for request header `Host` for DNS rebinding protection

--- a/src/lib/server-factory.ts
+++ b/src/lib/server-factory.ts
@@ -18,6 +18,7 @@ export interface ServerFactoryConfig {
   tlsConfig?: TlsConfig;
   enableAuth: boolean;
   enableTokenExchange: boolean;
+  configFolderPath: string;
 }
 
 /**
@@ -55,8 +56,8 @@ function createHttpsServer(app: express.Application, config: ServerFactoryConfig
   }
 
   try {
-    // Resolve key/cert relative to the project if paths provided in config are relative
-    const base = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../..');
+    // Resolve key/cert relative to the config folder if paths provided in config are relative
+    const base = config.configFolderPath;
     const keyPath = path.isAbsolute(config.tlsConfig.keyPath)
       ? config.tlsConfig.keyPath
       : path.join(base, config.tlsConfig.keyPath);

--- a/src/server.ts
+++ b/src/server.ts
@@ -119,7 +119,8 @@ async function main() {
           }
         : undefined,
       enableAuth: derivedConfig.enableAuth,
-      enableTokenExchange: derivedConfig.enableTokenExchange
+      enableTokenExchange: derivedConfig.enableTokenExchange,
+      configFolderPath: process.argv[2]
     });
 
     // Handle graceful shutdown


### PR DESCRIPTION
Fixes #77 